### PR TITLE
Algure variable progressbar

### DIFF
--- a/passwordstrength/src/main/java/com/android/thenishchalraj/passwordstrength/PasswordStrengthBar.java
+++ b/passwordstrength/src/main/java/com/android/thenishchalraj/passwordstrength/PasswordStrengthBar.java
@@ -124,7 +124,6 @@ public class PasswordStrengthBar extends LinearLayout{
     private void setCustomBarViews(){
         shouldUseCustomBars =true;
         setupStrengthColors(passBarsNum);
-        defaultBarColor = Color.DKGRAY;
         this.invalidate();
     }
 

--- a/passwordstrength/src/main/res/values/attr.xml
+++ b/passwordstrength/src/main/res/values/attr.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="shirt_view">
+        <attr name="leftfset" format="boolean"/>
+        <attr name="rightfset" format="boolean"/>
+        <attr name="middlefset" format="boolean"/>
+        <attr name="backbset" format="boolean"/>
+        <attr name="downbset" format="boolean"/>
+        <attr name="midbox" format="string"/>
+        <attr name="lbox" format="string"/>
+        <attr name="rbox" format="string"/>
+        <attr name="shirt_pic" format="reference"/>
+        <attr name="linkedId" format="integer"/>
+    </declare-styleable>
+    <declare-styleable name="PlaneCanvasView">
+        <attr name="strokesize" format="integer"/>
+        <attr name="showtextview" format="boolean"/>
+
+    </declare-styleable>
+
+</resources>

--- a/passwordstrength/src/main/res/values/attr.xml
+++ b/passwordstrength/src/main/res/values/attr.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <declare-styleable name="shirt_view">
-        <attr name="leftfset" format="boolean"/>
-        <attr name="rightfset" format="boolean"/>
-        <attr name="middlefset" format="boolean"/>
-        <attr name="backbset" format="boolean"/>
-        <attr name="downbset" format="boolean"/>
-        <attr name="midbox" format="string"/>
-        <attr name="lbox" format="string"/>
-        <attr name="rbox" format="string"/>
-        <attr name="shirt_pic" format="reference"/>
-        <attr name="linkedId" format="integer"/>
-    </declare-styleable>
-    <declare-styleable name="PlaneCanvasView">
-        <attr name="strokesize" format="integer"/>
-        <attr name="showtextview" format="boolean"/>
+    <declare-styleable name="clock_view">
+        <attr name="useSystemTime" format="boolean"/>
+        <attr name="hours" format="integer"/>
+        <attr name="minutes" format="integer"/>
+        <attr name="secs" format="integer"/>
+        <attr name="clockStroke" format="dimension"/>
+        <attr name="textSize" format="dimension"/>
+        <attr name="clockColor" format="color" />
+        <attr name="textColor" format="color" />
+        <attr name="clockBackColor" format="color"/>
 
     </declare-styleable>
+    <declare-styleable name="password_strength">
+        <attr name="maxProgress" format="integer"/>
+        <attr name="minProgress" format="integer"/>
+        <attr name="bars" format="integer"/>
+        <attr name="strength" format="integer"/>
+        <attr name="defColor" format="color"/>
 
+    </declare-styleable>
 </resources>

--- a/passwordstrength/src/main/res/values/attr.xml
+++ b/passwordstrength/src/main/res/values/attr.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <declare-styleable name="clock_view">
-        <attr name="useSystemTime" format="boolean"/>
-        <attr name="hours" format="integer"/>
-        <attr name="minutes" format="integer"/>
-        <attr name="secs" format="integer"/>
-        <attr name="clockStroke" format="dimension"/>
-        <attr name="textSize" format="dimension"/>
-        <attr name="clockColor" format="color" />
-        <attr name="textColor" format="color" />
-        <attr name="clockBackColor" format="color"/>
-
-    </declare-styleable>
     <declare-styleable name="password_strength">
         <attr name="maxProgress" format="integer"/>
         <attr name="minProgress" format="integer"/>


### PR DESCRIPTION
This patch allows the developer to specify a variable number of progressbars and automatically sets the range of colors from RED:weakest(left) to GREEN:strongest(right).
The bars attribute would have to be set in xml; failure to specify this attribute would automatically inflate the layout with four progressbars allowing user to specify colors, maximum and minimum as before.

other attributes can also be set in xml:
 name="maxProgress" format="integer"
 name="minProgress" format="integer"
 name="bars" format="integer"
 name="strength" format="integer"
 name="defColor" format="color"

sample:

    <com.android.thenishchalraj.PasswordStrengthBar
            android:layout_width="match_parent"
            android:layout_height="8dp"
            android:id="@+id/passStrength"
            android:background="@android:color/transparent"
            android:layout_gravity="center"
            app:defColor="#b3b3b3"
	###     app:bars="5"
            app:minProgress="10"
            app:maxProgress="400"
            app:strength="330"/>
![Screenshot_20201005-211110](https://user-images.githubusercontent.com/37802577/95127472-f211dd80-074f-11eb-8573-f6f672647382.png)
NOTE: The variable bars functionality CAN ONLY be triggered if set from xml not programmatically. The "setStrength(int strength)" method can still be used programmatically.

Hope this helps. 
fixes #4 
